### PR TITLE
Fix ServiceResult state string resolution

### DIFF
--- a/nrdpy/result.py
+++ b/nrdpy/result.py
@@ -258,7 +258,7 @@ class ServiceResult(object):
 
     def _get_state_string(self):
 
-        return HostResult._state_strings[self.__dict__['state']]
+        return ServiceResult._state_strings[self.__dict__['state']]
 
     def _set_state(self, value):
 


### PR DESCRIPTION
Hi, 

I came across this minor bug in your library where the ServiceResult state is resolved to string using HostResult state strings array. Please, consider my pull request for merging.

Thanks a lot

Kindest regards 

LS